### PR TITLE
Add eleMap Function to Matrix.prototype

### DIFF
--- a/build/buildMacros.coffee
+++ b/build/buildMacros.coffee
@@ -17,6 +17,12 @@ mathOp = (name, expr, param) ->
     .replace(/PARAM/g, param)
     .replace(/'EXPR'/g, expr)
 
+eleMathOp = (name, expr, exprVar1, exprVar2, param) ->
+  mathOpTempl
+    .replace(/NAME/g, name)
+    .replace(/PARAM/g, param)
+    .replace(/'EXPR'/g, expr + ", " + exprVar1 + ", " + exprVar2)
+
 
 
 module.exports = (fullStr, macroComps) ->
@@ -27,6 +33,8 @@ module.exports = (fullStr, macroComps) ->
       return algebraOp(tokens[1], tokens[2])
     when 'MATH_OP'
       return mathOp(tokens[1], tokens[2], tokens[3])
+    when 'ELE_MATH_OP'
+      return eleMathOp(tokens[1], tokens[2], tokens[3], tokens[4], tokens[5])
     else
       throw new Error('Unrecognized PRAGMA macro')
 

--- a/src/math-transforms.js
+++ b/src/math-transforms.js
@@ -31,3 +31,10 @@ BUILD(MATH_OP, mulEach, thisData[row][col] * value, value)
  * @param  {Number} value Value to multiple with.
  */
 BUILD(MATH_OP, plusEach, thisData[row][col] + value, value)
+
+/**
+ * Apply function with row and column parameters to all elements in matrix
+ *
+ * Used to apply different transformations depending on placement in matrix.
+ */
+BUILD(ELE_MATH_OP, eleMap, transformFn(thisData[row][col], row, col), transformFn)

--- a/test/_commonTests.js
+++ b/test/_commonTests.js
@@ -386,6 +386,174 @@ module.exports = function(linAlg, options) {
 
         stub.callCount.should.eql(6);          
       }
+    },
+    'eleMap': {
+      'default': {
+        'row transform': function() {
+          var stub = this.mocker.spy(function(v, row, col) {
+            switch (row){
+              case 0: return v * 2;
+              case 1: return v * 3;
+              default: return v * 10;
+            }
+          });
+          
+          var m = new this.Matrix([ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]);
+
+          var m2 = m.eleMap(stub);
+          m2.should.not.eql(m);
+
+          m2.data.should.not.eql(m.data);
+          m2.data.should.eql([ [2, 4, 6], [12, 15, 18], [70, 80, 90] ]);
+          m2.rows.should.eql(3);
+          m2.cols.should.eql(3);
+
+          stub.callCount.should.eql(9);
+        },
+        'column transform': function() {
+          var stub = this.mocker.spy(function(v, row, col) {
+            switch (col) {
+              case 0: return v * 2;
+              case 1: return v * 3;
+              default: return v * 10;
+            }
+          });
+
+          var m = new this.Matrix([ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]);
+
+          var m2 = m.eleMap(stub);
+          m2.should.not.eql(m);
+
+          m2.data.should.not.eql(m.data);
+          m2.data.should.eql([ [2, 6, 30], [8, 15, 60], [14, 24, 90] ]);
+          m2.rows.should.eql(3);
+          m2.cols.should.eql(3);
+
+          stub.callCount.should.eql(9);
+        },
+        'element transform': function() {
+          var stub = this.mocker.spy(function(v, row, col) {
+            switch (row) {
+              case 0:
+                //First row
+                switch (col) {
+                  case 0: return v + 1;
+                  case 1: return v + 2;
+                  default: return v + 3;
+                }
+              case 1:
+                //Second row
+                switch (col) {
+                  case 0: return v;
+                  case 1: return v * 2;
+                  default: return v * 3;
+                }
+              default:
+                // All other rows
+                switch (col) {
+                  case 0: return v - 1;
+                  case 1: return v - 2;
+                  default: return v -3;
+                }
+            }
+          });
+
+          var m = new this.Matrix([ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]);
+
+          var m2 = m.eleMap(stub);
+          m2.should.not.eql(m);
+
+          m2.data.should.not.eql(m.data);
+          m2.data.should.eql([ [2, 4, 6], [4, 10, 18], [6, 6, 6] ]);
+          m2.rows.should.eql(3);
+          m2.cols.should.eql(3);
+
+          stub.callCount.should.eql(9);
+        }
+      },
+      'in-place': {
+        'row transform': function() {
+          var stub = this.mocker.spy(function(v, row, col) {
+            switch (row){
+              case 0: return v * 2;
+              case 1: return v * 3;
+              default: return v * 10;
+            }
+          });
+          
+          var m = new this.Matrix([ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]);
+
+          var m2 = m.eleMap_(stub);
+          m2.should.eql(m);
+
+          m2.data.should.eql(m.data);
+          m2.data.should.eql([ [2, 4, 6], [12, 15, 18], [70, 80, 90] ]);
+          m2.rows.should.eql(3);
+          m2.cols.should.eql(3);
+
+          stub.callCount.should.eql(9);
+        },
+        'column transform': function() {
+           var stub = this.mocker.spy(function(v, row, col) {
+            switch (col) {
+              case 0: return v * 2;
+              case 1: return v * 3;
+              default: return v * 10;
+            }
+          });
+
+          var m = new this.Matrix([ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]);
+
+          var m2 = m.eleMap_(stub);
+          m2.should.eql(m);
+
+          m2.data.should.eql(m.data);
+          m2.data.should.eql([ [2, 6, 30], [8, 15, 60], [14, 24, 90] ]);
+          m2.rows.should.eql(3);
+          m2.cols.should.eql(3);
+
+          stub.callCount.should.eql(9);
+        },
+        'element transform': function() {
+          var stub = this.mocker.spy(function(v, row, col) {
+            switch (row) {
+              case 0:
+                //First row
+                switch (col) {
+                  case 0: return v + 1;
+                  case 1: return v + 2;
+                  default: return v + 3;
+                }
+              case 1:
+                //Second row
+                switch (col) {
+                  case 0: return v;
+                  case 1: return v * 2;
+                  default: return v * 3;
+                }
+              default:
+                //All other rows
+                switch (col) {
+                  case 0: return v - 1;
+                  case 1: return v - 2;
+                  default: return v -3;
+                }
+            }
+          });
+
+          var m = new this.Matrix([ [1, 2, 3], [4, 5, 6], [7, 8, 9] ]);
+
+          var m2 = m.eleMap_(stub);
+          m2.should.eql(m);
+
+          m2.data.should.eql(m.data);
+          m2.data.should.eql([ [2, 4, 6], [4, 10, 18], [6, 6, 6] ]);
+          m2.rows.should.eql(3);
+          m2.cols.should.eql(3);
+
+          stub.callCount.should.eql(9);
+        }
+      }
     }
   }
   


### PR DESCRIPTION
### eleMap overview
`eleMap` is allows finer control over the transformations done to a matrix. Like `map`, `eleMap` takes in a callback function. However, in addition to the current element's value, `eleMap` also passes in its row and column position to the callback function. An `eleMap` callback declaration might look like this:
```javascript
var cb = function(v, row, col) {
    switch (row) {
        case 0:
            // Perform transformation on first row
        case 1:
            // Perform transformation on second row
        default:
            // Perform transformation on all other rows
    }
}
````

Then we could apply this callback to a matrix, either in-place or returning a new matrix.
```javascript
// In-place transformation
m.eleMap_(cb);

// Return a new matrix
var m2 = m.eleMap(cb);
```

`eleMap` functions identically to `map` when `row` and `col` are omitted.

### Changes to existing files
* This pull makes changes to three files. A build command has been added to src/mathtransforms.js to create both `eleMap()` and `eleMap_()`. 
* In build/buildMacros.coffee, a new operation function, `eleMathOp` is added, as well as an additional case under `module.exports` to use it.
    * This is a somewhat ineloquent solution. Ideally, `eleMap` would be able to use the existing `mathOp` function. However, due to `macroComps` being split on commas (line 29 in new file, line 23 in old file), and the desired replacement for `'EXPR'` is `transformFn(thisData[row][col], row, col)`, it was deemed acceptable.
    * Theoretically, `macroComps` could be split on `', '` (note the space), and all the functions would work. However, not interfering with existing code was a goal of this merge.
* Several tests were added to test/_commonTests.js

### Tests
Six total tests were added in test/_commonTests.js. Three tests are conducted for both in-place and regular transformations- one testing row transformations, one testing column transformations, and one testing element-by-element transformations. These run alongside the other tests when the `gulp` command is used in the terminal.

### Some applications
* Applying different activation functions to different layers in a neural network
* Zeroing out specific rows, columns or elements based on position
* Basis of future convenience selector/application functions (something like `matrix.row(3).apply(function());`