### PR TITLE
normalize require and simplify index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var normal = require('./dist/linear-algebra'),
-  precision = require('./dist/linear-algebra.precision');
-
+    precision = require('./dist/linear-algebra.precision');
 
 /** 
  * Initialise the library.
@@ -10,18 +9,8 @@ var normal = require('./dist/linear-algebra'),
  * 
  * @return {Object} Linear algebra primitives.
  */
-var linearAlgebra = module.exports = function(options) {
+var linearAlgebra = module.exports = (function(options) {
   options = options || {};
   
-  if (options.add) {
-    return linearAlgebra._precision(options);
-  } else {
-    return linearAlgebra._normal(options);
-  }
-};
-
-
-// to make testing easier
-linearAlgebra._normal = normal;
-linearAlgebra._precision = precision;
-
+  return(options.add ? precision(options) : normal(options));
+})();


### PR DESCRIPTION
Currently, requiring the library returns a function, which must be called to access the Vector and Matrix classes, like:

const { Vector, Matrix } = require('linear-algebra')();

The documentation in quotes above the linearAlgebra function says that the library is supposed to return an Object. I've converted the linearAlgebra export to an immediately invoked function in this commit so that it does return an Object on requiring, and so that requiring can be done as in most JS libraries, like:

const { Vector, Matrix } = require('linear-algebra'); 

Also, absorbed precision() and normal() function calls into the IIFE, which gets rid of some vars.